### PR TITLE
Basic layout and open/export images

### DIFF
--- a/safe_video/ui/app.py
+++ b/safe_video/ui/app.py
@@ -4,6 +4,7 @@ from typing import Dict
 import os
 from safe_video.number_plate_recognition import NumberPlateRecognition
 from .dataclasses import Video, Image, ColorPalate
+from .components import PreviewImage
 
 CACHE_PATH = "safe_video/upload_cache/"
 
@@ -15,45 +16,51 @@ DarkColors = ColorPalate(
 
 class UI_App:
     def __init__(self):
-        self.images: list[Image] = []
-        self.current_image: int
+        self.images: dict[Image] = {}
         self.cache_path = f"safe_video/upload_cache/"
         self.page: ft.Page = None
         self.colors: ColorPalate = DarkColors
-        self.image_ref = ft.Ref[ft.Container]()
+        self.image_ref = ft.Ref[ft.Row]()
+        self.preview_bar_ref = ft.Ref[ft.Column]()
+        self.current_image_key: str
+        self.npr = NumberPlateRecognition()
 
     def blur_callback(self):
-        npr = NumberPlateRecognition(self.image_paths[-1])
-        npr.blur_image()
+        self.npr.blur_image()
 
     def upload_callback(self, file_results: ft.FilePickerResultEvent):
-        if file_results.files is None: return
+        if file_results.files is None or len(file_results.files) == 0: return
         for file in file_results.files:
             path =self.cache_path + file.name
             if not os.path.exists(self.cache_path):
                 os.makedirs(self.cache_path)
             shutil.copy(file.path, path)
             [name, format] = file.name.split(".", 1)
-            self.images.append(Image(cache_path=self.cache_path, original_path=file.path, name=name, format=format))
-            self.current_image = len(self.images)-1
+            self.images[name] = Image(cache_path=self.cache_path, original_path=file.path, name=name, format=format)
+            self.current_image = name
             
-            if self.image_ref.current is None:
-                img = ft.Container(ref=self.image_ref, image_src=path, image_fit=ft.ImageFit.CONTAIN, expand=True, margin=10)
-                self.page.add(img)
-            else:
-                self.image_ref.current.image_src=path
-                self.image_ref.current.update()
+            self.preview_bar_ref.current.controls.append(PreviewImage(name, path, self.switch_image))
+            self.preview_bar_ref.current.update()
+
+        self.current_image_key = name
+        self.image_ref.current.controls = [ft.Container(image_src=path, image_fit=ft.ImageFit.CONTAIN, expand=True, margin=10)]
+        self.image_ref.current.update()
     
+    def switch_image(self, info: ft.ControlEvent):
+        self.current_image_key = info.control.key
+        img = self.images[self.current_image_key]
+        self.image_ref.current.controls = [ft.Container(image_src=img.get_path(), image_fit=ft.ImageFit.CONTAIN, expand=True, margin=10)]
+        self.image_ref.current.update()
+
     def export_callback(self, file_results: ft.FilePickerResultEvent):
         if file_results.path is None: return
-        image = self.images[self.current_image]
+        img = self.images[self.current_image_key]
+        self.preview_bar_ref.current.controls = [c for c in self.preview_bar_ref.current.controls if c.key != img.name]
+        self.preview_bar_ref.current.update()
         export_path = file_results.path
         if '.' not in export_path:
-            export_path += '.' + image.format
-        shutil.move(image.get_path(), export_path)
-
-    def add_image(self, file: ft.file_picker.FilePickerFile):
-        pass
+            export_path += '.' + img.format
+        shutil.move(img.get_path(), export_path)
 
     def settings_callback(self):
         print('TODO: Settings')
@@ -62,20 +69,42 @@ class UI_App:
         self.page = page
         page.padding=0
         page.spacing=0
-        page.bgcolor = self.colors.normal
+        page.bgcolor = self.colors.light
         file_picker_open = ft.FilePicker(on_result=self.upload_callback)
         file_picker_export = ft.FilePicker(on_result=self.export_callback)
         page.overlay.append(file_picker_open)
         page.overlay.append(file_picker_export)
         page.add(
             ft.Container(ft.Row([
-                ft.ElevatedButton("Open Image", on_click=lambda _: file_picker_open.pick_files(file_type=ft.FilePickerFileType.IMAGE), icon=ft.icons.FOLDER_OPEN),
-                ft.ElevatedButton("Export file", on_click=lambda _: file_picker_export.save_file(initial_directory=self.images[self.current_image].original_path), icon=ft.icons.SAVE_ALT),
-                ft.ElevatedButton("Blur image", on_click=lambda _: self.blur_callback()),
+                ft.Container(content=ft.IconButton(ft.icons.BLUR_ON, focus_color=self.colors.dark), width=50),
+                ft.ElevatedButton("Open Image", on_click=lambda _: file_picker_open.pick_files(file_type=ft.FilePickerFileType.IMAGE, allow_multiple=True), icon=ft.icons.FOLDER_OPEN),
+                ft.ElevatedButton("Export file", on_click=lambda _: file_picker_export.save_file(file_name=self.images[self.current_image_key].name), icon=ft.icons.SAVE_ALT),
+                ft.ElevatedButton("Blur all", on_click=lambda _: self.blur_callback(), icon=ft.icons.PLAY_ARROW),
                 ft.Row([], expand=True),
                 ft.IconButton(on_click=lambda _: self.blur_callback(), icon=ft.icons.SETTINGS)
             ]), padding=10, bgcolor=self.colors.dark),
+            ft.Row([
+                ft.Container(ft.Column([], expand=True, spacing=10, ref=self.preview_bar_ref), bgcolor=self.colors.normal, padding=10, width=70),
+                ft.Row([], ref=self.image_ref, expand=True),
+                ft.Container(ft.Column([
+                    ft.ExpansionTile(
+                        title=ft.Text("Number Plates"),
+                        leading=ft.Checkbox(),
+                        shape=ft.StadiumBorder(),
+                        controls=[ft.Text("options")]
+                        ),
+                    ft.ExpansionTile(
+                        title=ft.Text("Faces"),
+                        leading=ft.Checkbox(),
+                        shape=ft.StadiumBorder(),
+                        controls=[ft.Text("options")]
+                        ),
+                ], expand=True), bgcolor=self.colors.normal, width=300, expand=0.5, alignment=ft.alignment.top_left),
+            ], expand=True),
+              
         )
+        self.image_ref.current.update()
+        self.preview_bar_ref.current.update()
 
     def run(self):
         ft.app(target=self.build_page)

--- a/safe_video/ui/app.py
+++ b/safe_video/ui/app.py
@@ -15,10 +15,12 @@ DarkColors = ColorPalate(
 
 class UI_App:
     def __init__(self):
-        self.image_paths = []
+        self.images: list[Image] = []
+        self.current_image: int
+        self.cache_path = f"safe_video/upload_cache/"
         self.page: ft.Page = None
-        self.columns = ft.Ref[ft.Column]()
         self.colors: ColorPalate = DarkColors
+        self.image_ref = ft.Ref[ft.Container]()
 
     def blur_callback(self):
         npr = NumberPlateRecognition(self.image_paths[-1])
@@ -27,37 +29,52 @@ class UI_App:
     def upload_callback(self, file_results: ft.FilePickerResultEvent):
         if file_results.files is None: return
         for file in file_results.files:
-            destination_path = f"safe_video/upload_cache/"
-            if not os.path.exists(destination_path):
-                os.makedirs(destination_path)
-            shutil.copy(file.path, destination_path + file.name)
-            img = ft.Container(image_src=destination_path + file.name, image_fit=ft.ImageFit.CONTAIN, expand=True, bgcolor='#1c2130')
-            self.image_paths.append(destination_path + file.name)
-            #self.current_img.current.image_src = destination_path + file.name
-            self.columns.current.controls.append(img)
-            #self.page.add(img)
-            self.page.update()
+            path =self.cache_path + file.name
+            if not os.path.exists(self.cache_path):
+                os.makedirs(self.cache_path)
+            shutil.copy(file.path, path)
+            [name, format] = file.name.split(".", 1)
+            self.images.append(Image(cache_path=self.cache_path, original_path=file.path, name=name, format=format))
+            self.current_image = len(self.images)-1
+            
+            if self.image_ref.current is None:
+                img = ft.Container(ref=self.image_ref, image_src=path, image_fit=ft.ImageFit.CONTAIN, expand=True, margin=10)
+                self.page.add(img)
+            else:
+                self.image_ref.current.image_src=path
+                self.image_ref.current.update()
+    
+    def export_callback(self, file_results: ft.FilePickerResultEvent):
+        if file_results.path is None: return
+        image = self.images[self.current_image]
+        export_path = file_results.path
+        if '.' not in export_path:
+            export_path += '.' + image.format
+        shutil.move(image.get_path(), export_path)
+
+    def add_image(self, file: ft.file_picker.FilePickerFile):
+        pass
+
+    def settings_callback(self):
+        print('TODO: Settings')
 
     def build_page(self, page: ft.Page):
         self.page = page
         page.padding=0
+        page.spacing=0
         page.bgcolor = self.colors.normal
-        Mypick = ft.FilePicker(on_result=self.upload_callback)
-        page.overlay.append(Mypick)
+        file_picker_open = ft.FilePicker(on_result=self.upload_callback)
+        file_picker_export = ft.FilePicker(on_result=self.export_callback)
+        page.overlay.append(file_picker_open)
+        page.overlay.append(file_picker_export)
         page.add(
-            ft.Column([
-                ft.Container(ft.Row([
-                    ft.ElevatedButton("Open file", on_click=lambda _: Mypick.pick_files()),
-                    ft.ElevatedButton("Export file", on_click=lambda _: Mypick.pick_files()),
-                    ft.ElevatedButton("Blur image", on_click=lambda _: self.blur_callback())
-                ]), padding=10, bgcolor=self.colors.dark),
-                #ft.Container(content=ft.Text("a"), expand=True, bgcolor='#1c2130'),
-                ft.Container(ft.Row([
-                    ft.ElevatedButton("Open file", on_click=lambda _: Mypick.pick_files()),
-                    ft.ElevatedButton("Export file", on_click=lambda _: Mypick.pick_files()),
-                    ft.ElevatedButton("Blur image", on_click=lambda _: self.blur_callback())
-                ]), padding=10)
-            ], ref=self.columns)
+            ft.Container(ft.Row([
+                ft.ElevatedButton("Open Image", on_click=lambda _: file_picker_open.pick_files(file_type=ft.FilePickerFileType.IMAGE), icon=ft.icons.FOLDER_OPEN),
+                ft.ElevatedButton("Export file", on_click=lambda _: file_picker_export.save_file(initial_directory=self.images[self.current_image].original_path), icon=ft.icons.SAVE_ALT),
+                ft.ElevatedButton("Blur image", on_click=lambda _: self.blur_callback()),
+                ft.Row([], expand=True),
+                ft.IconButton(on_click=lambda _: self.blur_callback(), icon=ft.icons.SETTINGS)
+            ]), padding=10, bgcolor=self.colors.dark),
         )
 
     def run(self):

--- a/safe_video/ui/app.py
+++ b/safe_video/ui/app.py
@@ -1,37 +1,66 @@
 import flet as ft
 import shutil
+from typing import Dict
 import os
 from safe_video.number_plate_recognition import NumberPlateRecognition
+from .dataclasses import Video, Image, ColorPalate
+
+CACHE_PATH = "safe_video/upload_cache/"
+
+DarkColors = ColorPalate(
+    normal = "#1a1e26",
+    light = "#232833",
+    dark = "#101217",
+)
 
 class UI_App:
     def __init__(self):
-        self.images = []
+        self.image_paths = []
         self.page: ft.Page = None
+        self.columns = ft.Ref[ft.Column]()
+        self.colors: ColorPalate = DarkColors
 
     def blur_callback(self):
-        npr = NumberPlateRecognition(self.images[-1])
+        npr = NumberPlateRecognition(self.image_paths[-1])
         npr.blur_image()
 
     def upload_callback(self, file_results: ft.FilePickerResultEvent):
+        if file_results.files is None: return
         for file in file_results.files:
             destination_path = f"safe_video/upload_cache/"
             if not os.path.exists(destination_path):
                 os.makedirs(destination_path)
             shutil.copy(file.path, destination_path + file.name)
-            img = ft.Image(src=destination_path + file.name, width=100, height=100, fit=ft.ImageFit.CONTAIN)
-            self.images.append(destination_path + file.name)
-            self.page.add(img)
+            img = ft.Container(image_src=destination_path + file.name, image_fit=ft.ImageFit.CONTAIN, expand=True, bgcolor='#1c2130')
+            self.image_paths.append(destination_path + file.name)
+            #self.current_img.current.image_src = destination_path + file.name
+            self.columns.current.controls.append(img)
+            #self.page.add(img)
+            self.page.update()
 
     def build_page(self, page: ft.Page):
         self.page = page
+        page.padding=0
+        page.bgcolor = self.colors.normal
         Mypick = ft.FilePicker(on_result=self.upload_callback)
         page.overlay.append(Mypick)
         page.add(
-            ft.Row([
-                ft.ElevatedButton("Insert file", on_click=lambda _: Mypick.pick_files()),
-                ft.ElevatedButton("Blur image", on_click=lambda _: self.blur_callback())
-                ])
+            ft.Column([
+                ft.Container(ft.Row([
+                    ft.ElevatedButton("Open file", on_click=lambda _: Mypick.pick_files()),
+                    ft.ElevatedButton("Export file", on_click=lambda _: Mypick.pick_files()),
+                    ft.ElevatedButton("Blur image", on_click=lambda _: self.blur_callback())
+                ]), padding=10, bgcolor=self.colors.dark),
+                #ft.Container(content=ft.Text("a"), expand=True, bgcolor='#1c2130'),
+                ft.Container(ft.Row([
+                    ft.ElevatedButton("Open file", on_click=lambda _: Mypick.pick_files()),
+                    ft.ElevatedButton("Export file", on_click=lambda _: Mypick.pick_files()),
+                    ft.ElevatedButton("Blur image", on_click=lambda _: self.blur_callback())
+                ]), padding=10)
+            ], ref=self.columns)
         )
 
     def run(self):
         ft.app(target=self.build_page)
+
+

--- a/safe_video/ui/app.py
+++ b/safe_video/ui/app.py
@@ -1,15 +1,14 @@
 import flet as ft
 import shutil
 from typing import Dict
-from typing import Dict
 import os
 from safe_video.number_plate_recognition import NumberPlateRecognition
-from .dataclasses import Video, Image, ColorPalate
+from .dataclasses import Video, Image, ColorPalette
 from .components import PreviewImage
 
 CACHE_PATH = "safe_video/upload_cache/"
 
-DarkColors = ColorPalate(
+DarkColors = ColorPalette(
     normal = "#1a1e26",
     light = "#232833",
     dark = "#101217",
@@ -20,7 +19,7 @@ class UI_App:
         self.images: dict[Image] = {}
         self.cache_path = f"safe_video/upload_cache/"
         self.page: ft.Page = None
-        self.colors: ColorPalate = DarkColors
+        self.colors: ColorPalette = DarkColors
         self.image_ref = ft.Ref[ft.Row]()
         self.preview_bar_ref = ft.Ref[ft.Column]()
         self.current_image_key: str
@@ -32,21 +31,21 @@ class UI_App:
     def upload_callback(self, file_results: ft.FilePickerResultEvent):
         if file_results.files is None or len(file_results.files) == 0: return
         for file in file_results.files:
-            path =self.cache_path + file.name
+            path = self.cache_path + file.name
             if not os.path.exists(self.cache_path):
                 os.makedirs(self.cache_path)
             shutil.copy(file.path, path)
             [name, format] = file.name.split(".", 1)
             self.images[name] = Image(cache_path=self.cache_path, original_path=file.path, name=name, format=format)
             self.current_image = name
-            
+
             self.preview_bar_ref.current.controls.append(PreviewImage(name, path, self.switch_image))
             self.preview_bar_ref.current.update()
 
         self.current_image_key = name
         self.image_ref.current.controls = [ft.Container(image_src=path, image_fit=ft.ImageFit.CONTAIN, expand=True, margin=10)]
         self.image_ref.current.update()
-    
+
     def switch_image(self, info: ft.ControlEvent):
         self.current_image_key = info.control.key
         img = self.images[self.current_image_key]
@@ -68,8 +67,8 @@ class UI_App:
 
     def build_page(self, page: ft.Page):
         self.page = page
-        page.padding=0
-        page.spacing=0
+        page.padding = 0
+        page.spacing = 0
         page.bgcolor = self.colors.light
         file_picker_open = ft.FilePicker(on_result=self.upload_callback)
         file_picker_export = ft.FilePicker(on_result=self.export_callback)
@@ -102,7 +101,6 @@ class UI_App:
                         ),
                 ], expand=True), bgcolor=self.colors.normal, width=300, expand=0.5, alignment=ft.alignment.top_left),
             ], expand=True),
-              
         )
         self.image_ref.current.update()
         self.preview_bar_ref.current.update()

--- a/safe_video/ui/app.py
+++ b/safe_video/ui/app.py
@@ -63,7 +63,7 @@ class UI_App:
             export_path += '.' + img.format
         shutil.move(img.get_path(), export_path)
 
-    def settings_callback(self):
+    def settings_callback(self, info: ft.ControlEvent):
         print('TODO: Settings')
 
     def build_page(self, page: ft.Page):
@@ -82,7 +82,7 @@ class UI_App:
                 ft.ElevatedButton("Export file", on_click=lambda _: file_picker_export.save_file(file_name=self.images[self.current_image_key].name), icon=ft.icons.SAVE_ALT),
                 ft.ElevatedButton("Blur all", on_click=lambda _: self.blur_callback(), icon=ft.icons.PLAY_ARROW),
                 ft.Row([], expand=True),
-                ft.IconButton(on_click=lambda _: self.blur_callback(), icon=ft.icons.SETTINGS)
+                ft.IconButton(on_click=self.settings_callback, icon=ft.icons.SETTINGS)
             ]), padding=10, bgcolor=self.colors.dark),
             ft.Row([
                 ft.Container(ft.Column([], expand=True, spacing=10, ref=self.preview_bar_ref), bgcolor=self.colors.normal, padding=10, width=70),

--- a/safe_video/ui/components.py
+++ b/safe_video/ui/components.py
@@ -1,0 +1,16 @@
+import flet as ft
+
+from .dataclasses import Image
+
+class PreviewImage(ft.Container):
+    def __init__(self, key, path, callback):
+        super().__init__(
+            key=key,
+            image_src=path,
+            width=50,
+            height=50,
+            on_click=callback,
+            image_fit=ft.ImageFit.FILL,
+            border_radius=3, 
+            image_opacity=0.8
+        )

--- a/safe_video/ui/components.py
+++ b/safe_video/ui/components.py
@@ -10,7 +10,6 @@ class PreviewImage(ft.Container):
             width=50,
             height=50,
             on_click=callback,
-            image_fit=ft.ImageFit.FILL,
-            border_radius=3, 
-            image_opacity=0.8
+            image_fit=ft.ImageFit.COVER,
+            border_radius=10,
         )

--- a/safe_video/ui/dataclasses.py
+++ b/safe_video/ui/dataclasses.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+@dataclass
+class Video:
+    cache_path: str
+    original_path: str
+    name: str
+
+
+@dataclass
+class Image:
+    cache_path: str
+    original_path: str
+    name: str
+
+@dataclass
+class ColorPalate:
+    normal: str
+    light: str
+    dark: str

--- a/safe_video/ui/dataclasses.py
+++ b/safe_video/ui/dataclasses.py
@@ -17,8 +17,9 @@ class Image:
     def get_path(self):
         return self.cache_path + self.name + '.' + self.format
 
+
 @dataclass
-class ColorPalate:
+class ColorPalette:
     normal: str
     light: str
     dark: str

--- a/safe_video/ui/dataclasses.py
+++ b/safe_video/ui/dataclasses.py
@@ -12,6 +12,10 @@ class Image:
     cache_path: str
     original_path: str
     name: str
+    format: str
+
+    def get_path(self):
+        return self.cache_path + self.name + '.' + self.format
 
 @dataclass
 class ColorPalate:


### PR DESCRIPTION
## Changes

- Images can be imported with a button and are copied into a cache folder
- Information to images is saved in `self.images` dictonary
- A preview of the open images are displayed on the left
- Images can be exported (moved to an other directory from the cache folder
- Options for the diffrent models on the right

## Has to be done in the future

- #11
- #12
- #10 To make it more readable